### PR TITLE
feat: add selective middleware support

### DIFF
--- a/blade-core/src/main/java/com/hellokaton/blade/Blade.java
+++ b/blade-core/src/main/java/com/hellokaton/blade/Blade.java
@@ -28,6 +28,7 @@ import com.hellokaton.blade.mvc.handler.DefaultExceptionHandler;
 import com.hellokaton.blade.mvc.handler.ExceptionHandler;
 import com.hellokaton.blade.mvc.handler.RouteHandler;
 import com.hellokaton.blade.mvc.hook.WebHook;
+import com.hellokaton.blade.mvc.hook.WebHookRule;
 import com.hellokaton.blade.mvc.http.HttpMethod;
 import com.hellokaton.blade.mvc.http.session.SessionManager;
 import com.hellokaton.blade.mvc.route.RouteMatcher;
@@ -540,6 +541,12 @@ public class Blade {
             this.routeMatcher.addMiddleware(webHook);
             this.register(webHook);
         }
+        return this;
+    }
+
+    public Blade use(@NonNull WebHook middleware, @NonNull WebHookRule rule) {
+        this.routeMatcher.addMiddleware(middleware, rule);
+        this.register(middleware);
         return this;
     }
 

--- a/blade-core/src/main/java/com/hellokaton/blade/mvc/hook/Middleware.java
+++ b/blade-core/src/main/java/com/hellokaton/blade/mvc/hook/Middleware.java
@@ -1,0 +1,174 @@
+package com.hellokaton.blade.mvc.hook;
+
+import com.hellokaton.blade.mvc.RouteContext;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+/**
+ * Holder for a {@link WebHook} along with its matching rules.
+ */
+@Getter
+@Slf4j
+public class Middleware {
+
+    private static final String LOG_PREFIX = "[SelectiveMiddleware]";
+
+    private final WebHook hook;
+    private final List<Pattern> include;
+    private final List<Pattern> exclude;
+    private final Set<String> methods;
+    private final int priority;
+    private final Predicate<RouteContext> condition;
+    private final long order;
+
+    // for duplicate detection
+    private final Set<String> includeStrings;
+    private final Set<String> excludeStrings;
+
+    Middleware(WebHook hook, WebHookRule rule, long order) {
+        this.hook = hook;
+        this.includeStrings = normalizePatterns(rule.getInclude());
+        this.excludeStrings = normalizePatterns(rule.getExclude());
+        this.include = compile(this.includeStrings);
+        this.exclude = compile(this.excludeStrings);
+        this.methods = rule.getMethods();
+        this.priority = rule.getPriority();
+        this.condition = rule.getCondition();
+        this.order = order;
+    }
+
+    /** Normalize and percent-decode a path or pattern. */
+    static String normalize(String path) {
+        if (path == null || path.isEmpty()) {
+            return "/";
+        }
+        String result;
+        try {
+            result = URLDecoder.decode(path, StandardCharsets.UTF_8.name());
+        } catch (Exception e) {
+            result = path;
+        }
+        int q = result.indexOf('?');
+        if (q >= 0) {
+            result = result.substring(0, q);
+        }
+        int f = result.indexOf('#');
+        if (f >= 0) {
+            result = result.substring(0, f);
+        }
+        result = result.replaceAll("/+", "/");
+        if (!result.startsWith("/")) {
+            result = "/" + result;
+        }
+        if (result.length() > 1 && result.endsWith("/")) {
+            result = result.substring(0, result.length() - 1);
+        }
+        return result.toLowerCase(Locale.ROOT);
+    }
+
+    private static Set<String> normalizePatterns(List<String> patterns) {
+        Set<String> set = new LinkedHashSet<>();
+        for (String p : patterns) {
+            if (p != null) {
+                set.add(normalize(p));
+            }
+        }
+        return set;
+    }
+
+    private static List<Pattern> compile(Set<String> patterns) {
+        List<Pattern> list = new ArrayList<>();
+        for (String p : patterns) {
+            list.add(globToRegex(p));
+        }
+        return list;
+    }
+
+    private static Pattern globToRegex(String pattern) {
+        if ("/".equals(pattern)) {
+            return Pattern.compile("^.*$", Pattern.CASE_INSENSITIVE);
+        }
+        StringBuilder sb = new StringBuilder();
+        boolean escaping = false;
+        for (int i = 0; i < pattern.length(); i++) {
+            char c = pattern.charAt(i);
+            if (escaping) {
+                sb.append(Pattern.quote(String.valueOf(c)));
+                escaping = false;
+                continue;
+            }
+            if (c == '\\') {
+                if (i == pattern.length() - 1) {
+                    log.warn("{} Malformed pattern '{}'", LOG_PREFIX, pattern);
+                    sb.append("\\\\");
+                } else {
+                    escaping = true;
+                }
+            } else if (c == '*') {
+                sb.append(".*");
+            } else if (c == '?') {
+                sb.append("[^/]");
+            } else {
+                sb.append(Pattern.quote(String.valueOf(c)));
+            }
+        }
+        String regex = "^" + sb + "/?$"; // allow optional trailing slash
+        return Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+    }
+
+    public boolean matches(String path, String method, RouteContext ctx) {
+        try {
+            if (!matchAny(include, path)) {
+                return false;
+            }
+            if (matchAny(exclude, path)) {
+                return false;
+            }
+            if (!methods.isEmpty() && !methods.contains(method)) {
+                return false;
+            }
+            if (condition != null) {
+                try {
+                    if (!condition.test(ctx)) {
+                        return false;
+                    }
+                } catch (Exception e) {
+                    log.warn("{} Condition error", LOG_PREFIX, e);
+                    return false;
+                }
+            }
+            return true;
+        } catch (Exception e) {
+            log.warn("{} Match error", LOG_PREFIX, e);
+            return false;
+        }
+    }
+
+    private boolean matchAny(List<Pattern> patterns, String path) {
+        if (patterns.isEmpty()) {
+            return true;
+        }
+        for (Pattern p : patterns) {
+            if (p.matcher(path).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    boolean isSame(Middleware other) {
+        return this.hook == other.hook
+                && this.priority == other.priority
+                && this.condition == other.condition
+                && this.methods.equals(other.methods)
+                && this.includeStrings.equals(other.includeStrings)
+                && this.excludeStrings.equals(other.excludeStrings);
+    }
+}
+

--- a/blade-core/src/main/java/com/hellokaton/blade/mvc/hook/WebHookRule.java
+++ b/blade-core/src/main/java/com/hellokaton/blade/mvc/hook/WebHookRule.java
@@ -1,0 +1,102 @@
+package com.hellokaton.blade.mvc.hook;
+
+import com.hellokaton.blade.mvc.RouteContext;
+
+import java.util.*;
+import java.util.function.Predicate;
+
+/**
+ * Options for registering {@link WebHook} middleware.
+ *
+ * <p>The rule provides fine grained controls on when a middleware
+ * should be executed. All fields are optional and will fall back to
+ * the defaults described in the selective middleware specification.</p>
+ */
+public class WebHookRule {
+
+    private final List<String> include = new ArrayList<>();
+    private final List<String> exclude = new ArrayList<>();
+    private final Set<String> methods = new LinkedHashSet<>();
+    private int priority = 0;
+    private Predicate<RouteContext> condition = null;
+
+    /**
+     * Add include patterns. If none supplied a single pattern of "/" will
+     * be used which matches every request path.
+     */
+    public WebHookRule include(String... patterns) {
+        if (patterns != null) {
+            Collections.addAll(this.include, patterns);
+        }
+        return this;
+    }
+
+    /**
+     * Add exclude patterns.
+     */
+    public WebHookRule exclude(String... patterns) {
+        if (patterns != null) {
+            Collections.addAll(this.exclude, patterns);
+        }
+        return this;
+    }
+
+    /**
+     * Restrict the hook to the given HTTP methods. The values are case
+     * insensitive and will be stored in upper case. Duplicated entries are
+     * ignored. Passing an empty array keeps the default of matching all
+     * methods.
+     */
+    public WebHookRule methods(String... methods) {
+        if (methods != null) {
+            for (String m : methods) {
+                if (m != null && !m.isEmpty()) {
+                    this.methods.add(m.toUpperCase(Locale.ROOT));
+                }
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Set priority. Lower values will execute earlier. Defaults to {@code 0}.
+     */
+    public WebHookRule priority(int priority) {
+        this.priority = priority;
+        return this;
+    }
+
+    /**
+     * Set runtime condition. If provided it must evaluate to {@code true}
+     * for the hook to be executed. If {@code null} the condition always
+     * passes.
+     */
+    public WebHookRule condition(Predicate<RouteContext> condition) {
+        this.condition = condition;
+        return this;
+    }
+
+    public List<String> getInclude() {
+        if (this.include.isEmpty()) {
+            return Collections.singletonList("/");
+        }
+        return this.include;
+    }
+
+    public List<String> getExclude() {
+        return this.exclude;
+    }
+
+    public Set<String> getMethods() {
+        return this.methods;
+    }
+
+    public int getPriority() {
+        return this.priority;
+    }
+
+    public Predicate<RouteContext> getCondition() {
+        return this.condition;
+    }
+}
+

--- a/blade-core/src/test/java/com/hellokaton/blade/mvc/hook/SelectiveMiddlewareTest.java
+++ b/blade-core/src/test/java/com/hellokaton/blade/mvc/hook/SelectiveMiddlewareTest.java
@@ -1,0 +1,93 @@
+package com.hellokaton.blade.mvc.hook;
+
+import com.hellokaton.blade.Blade;
+import com.hellokaton.blade.mvc.RouteContext;
+import com.hellokaton.blade.mvc.http.Request;
+import com.hellokaton.blade.mvc.http.Response;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for selective middleware registration and matching.
+ */
+public class SelectiveMiddlewareTest {
+
+    private RouteContext ctx(String method, String uri) {
+        Request req = mock(Request.class);
+        when(req.method()).thenReturn(method);
+        when(req.uri()).thenReturn(uri);
+        return new RouteContext(req, mock(Response.class));
+    }
+
+    @Test
+    public void testBasicFiltering() {
+        Blade blade = Blade.create();
+        WebHook all = mock(WebHook.class);
+        blade.use(all);
+
+        WebHook selective = mock(WebHook.class);
+        WebHookRule rule = new WebHookRule()
+                .include("/foo/*")
+                .exclude("/foo/skip")
+                .methods("GET");
+        blade.use(selective, rule);
+
+        List<Middleware> m1 = blade.routeMatcher().getMiddleware(ctx("GET", "/foo/bar"));
+        assertEquals(2, m1.size());
+        assertSame(all, m1.get(0).getHook());
+        assertSame(selective, m1.get(1).getHook());
+
+        List<Middleware> m2 = blade.routeMatcher().getMiddleware(ctx("GET", "/foo/skip"));
+        assertEquals(1, m2.size());
+        assertSame(all, m2.get(0).getHook());
+
+        List<Middleware> m3 = blade.routeMatcher().getMiddleware(ctx("POST", "/foo/bar"));
+        assertEquals(1, m3.size());
+        assertSame(all, m3.get(0).getHook());
+    }
+
+    @Test
+    public void testPriorityOrder() {
+        Blade blade = Blade.create();
+        WebHook h1 = mock(WebHook.class);
+        WebHook h2 = mock(WebHook.class);
+        WebHook h3 = mock(WebHook.class);
+
+        blade.use(h1, new WebHookRule().priority(5));
+        blade.use(h2, new WebHookRule().priority(5));
+        blade.use(h3, new WebHookRule().priority(-1));
+
+        List<Middleware> m = blade.routeMatcher().getMiddleware(ctx("GET", "/"));
+        assertEquals(3, m.size());
+        assertSame(h3, m.get(0).getHook());
+        assertSame(h1, m.get(1).getHook());
+        assertSame(h2, m.get(2).getHook());
+    }
+
+    @Test
+    public void testCondition() {
+        Blade blade = Blade.create();
+        WebHook cond = mock(WebHook.class);
+        WebHookRule rule = new WebHookRule().condition(c -> false);
+        blade.use(cond, rule);
+
+        List<Middleware> m = blade.routeMatcher().getMiddleware(ctx("GET", "/"));
+        assertTrue(m.isEmpty());
+    }
+
+    @Test
+    public void testDuplicateIgnored() {
+        Blade blade = Blade.create();
+        WebHook hook = mock(WebHook.class);
+        blade.use(hook);
+        blade.use(hook); // duplicate
+
+        List<Middleware> m = blade.routeMatcher().getMiddleware(ctx("GET", "/"));
+        assertEquals(1, m.size());
+    }
+}
+


### PR DESCRIPTION
## Summary
- support registering middleware with include/exclude patterns, methods, priority and conditions via new `WebHookRule`
- execute only matching middleware, sorted by priority and registration order
- added unit tests covering selective middleware behavior

## Testing
- `mvn -q -pl blade-core test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: The following artifacts could not be resolved: org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 (absent): Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a66580a88326ab749f4932ac6efe