### PR TITLE
Add selective middleware invocation

### DIFF
--- a/blade-core/src/main/java/com/hellokaton/blade/Blade.java
+++ b/blade-core/src/main/java/com/hellokaton/blade/Blade.java
@@ -28,6 +28,7 @@ import com.hellokaton.blade.mvc.handler.DefaultExceptionHandler;
 import com.hellokaton.blade.mvc.handler.ExceptionHandler;
 import com.hellokaton.blade.mvc.handler.RouteHandler;
 import com.hellokaton.blade.mvc.hook.WebHook;
+import com.hellokaton.blade.mvc.hook.WebHookOptions;
 import com.hellokaton.blade.mvc.http.HttpMethod;
 import com.hellokaton.blade.mvc.http.session.SessionManager;
 import com.hellokaton.blade.mvc.route.RouteMatcher;
@@ -537,9 +538,23 @@ public class Blade {
             return this;
         }
         for (WebHook webHook : middleware) {
-            this.routeMatcher.addMiddleware(webHook);
+            WebHookOptions options = new WebHookOptions().addInclude("/**");
+            this.routeMatcher.addMiddleware(webHook, options);
             this.register(webHook);
         }
+        return this;
+    }
+
+    /**
+     * Register middleware with options
+     *
+     * @param middleware middleware instance
+     * @param options    hook options
+     * @return blade
+     */
+    public Blade use(@NonNull WebHook middleware, @NonNull WebHookOptions options) {
+        this.routeMatcher.addMiddleware(middleware, options);
+        this.register(middleware);
         return this;
     }
 

--- a/blade-core/src/main/java/com/hellokaton/blade/mvc/hook/WebHookOptions.java
+++ b/blade-core/src/main/java/com/hellokaton/blade/mvc/hook/WebHookOptions.java
@@ -1,0 +1,181 @@
+package com.hellokaton.blade.mvc.hook;
+
+import com.hellokaton.blade.mvc.RouteContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.function.Predicate;
+
+/**
+ * Options for WebHook selective execution.
+ */
+public class WebHookOptions {
+
+    private static final Logger log = LoggerFactory.getLogger(WebHookOptions.class);
+
+    private final List<String> includes = new ArrayList<>();
+    private final List<Pattern> includePatterns = new ArrayList<>();
+    private final List<String> excludes = new ArrayList<>();
+    private final List<Pattern> excludePatterns = new ArrayList<>();
+    private final Set<String> methods = new LinkedHashSet<>();
+    private int priority = 0;
+    private Predicate<RouteContext> predicate = ctx -> true;
+
+    public WebHookOptions() {
+    }
+
+    public WebHookOptions addInclude(String pattern) {
+        String norm = normalizePath(pattern);
+        includes.add(norm);
+        includePatterns.add(compilePattern(norm));
+        return this;
+    }
+
+    public WebHookOptions addExclude(String pattern) {
+        String norm = normalizePath(pattern);
+        excludes.add(norm);
+        excludePatterns.add(compilePattern(norm));
+        return this;
+    }
+
+    public WebHookOptions addMethods(String... methods) {
+        if (null == methods) return this;
+        for (String m : methods) {
+            if (null == m) continue;
+            this.methods.add(m.toUpperCase(Locale.ROOT));
+        }
+        return this;
+    }
+
+    public WebHookOptions priority(int priority) {
+        this.priority = priority;
+        return this;
+    }
+
+    public WebHookOptions condition(Predicate<RouteContext> predicate) {
+        if (null != predicate) {
+            this.predicate = predicate;
+        }
+        return this;
+    }
+
+    public List<String> getIncludes() {
+        return includes;
+    }
+
+    public List<String> getExcludes() {
+        return excludes;
+    }
+
+    public Set<String> getMethods() {
+        return methods;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public Predicate<RouteContext> getPredicate() {
+        return predicate;
+    }
+
+    boolean matches(String method, String path) {
+        String m = method == null ? "" : method.toUpperCase(Locale.ROOT);
+        String p = normalizePath(path);
+
+        boolean matched = false;
+        if (includePatterns.isEmpty()) {
+            matched = true;
+        } else {
+            for (Pattern pattern : includePatterns) {
+                if (pattern.matcher(p).matches()) {
+                    matched = true;
+                    break;
+                }
+            }
+        }
+        if (!matched) return false;
+        for (Pattern pattern : excludePatterns) {
+            if (pattern.matcher(p).matches()) {
+                return false;
+            }
+        }
+        if (!methods.isEmpty() && !methods.contains(m)) {
+            return false;
+        }
+        return true;
+    }
+
+    static String normalizePath(String path) {
+        if (null == path || path.isEmpty()) {
+            return "/";
+        }
+        String result;
+        try {
+            result = URLDecoder.decode(path, StandardCharsets.UTF_8.name());
+        } catch (Exception e) {
+            result = path;
+        }
+        int q = result.indexOf('?');
+        if (q >= 0) result = result.substring(0, q);
+        int f = result.indexOf('#');
+        if (f >= 0) result = result.substring(0, f);
+        result = result.replaceAll("/+", "/");
+        if (!result.startsWith("/")) result = "/" + result;
+        if (result.length() > 1 && result.endsWith("/")) result = result.substring(0, result.length() - 1);
+        return result.toLowerCase(Locale.ROOT);
+    }
+
+    private static Pattern compilePattern(String pattern) {
+        StringBuilder regex = new StringBuilder();
+        boolean escaping = false;
+        for (int i = 0; i < pattern.length(); i++) {
+            char c = pattern.charAt(i);
+            if (escaping) {
+                regex.append(Pattern.quote(String.valueOf(c)));
+                escaping = false;
+                continue;
+            }
+            switch (c) {
+                case '\\':
+                    escaping = true;
+                    break;
+                case '*':
+                    regex.append(".*");
+                    break;
+                case '?':
+                    regex.append("[^/]");
+                    break;
+                default:
+                    regex.append(Pattern.quote(String.valueOf(c)));
+            }
+        }
+        if (escaping) {
+            log.warn("SelectiveMiddleware: Dangling escape in pattern: {}", pattern);
+            regex.append("\\\\");
+        }
+        return Pattern.compile("^" + regex + "$", Pattern.CASE_INSENSITIVE);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof WebHookOptions)) return false;
+        WebHookOptions that = (WebHookOptions) o;
+        return priority == that.priority &&
+                Objects.equals(includes, that.includes) &&
+                Objects.equals(excludes, that.excludes) &&
+                Objects.equals(methods, that.methods) &&
+                Objects.equals(predicate, that.predicate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(includes, excludes, methods, priority, predicate);
+    }
+}
+

--- a/blade-core/src/main/java/com/hellokaton/blade/mvc/route/WebHookRoute.java
+++ b/blade-core/src/main/java/com/hellokaton/blade/mvc/route/WebHookRoute.java
@@ -1,0 +1,38 @@
+package com.hellokaton.blade.mvc.route;
+
+import com.hellokaton.blade.mvc.hook.WebHook;
+import com.hellokaton.blade.mvc.hook.WebHookOptions;
+import com.hellokaton.blade.mvc.http.HttpMethod;
+
+import java.lang.reflect.Method;
+
+/**
+ * Route wrapper for WebHook with options and order.
+ */
+public class WebHookRoute extends Route {
+
+    private final WebHook webHook;
+    private final WebHookOptions options;
+    private final int order;
+
+    public WebHookRoute(HttpMethod httpMethod, String path, WebHook webHook,
+                        Class<?> targetType, Method action, WebHookOptions options, int order) {
+        super(httpMethod, path, webHook, targetType, action, null);
+        this.webHook = webHook;
+        this.options = options;
+        this.order = order;
+    }
+
+    public WebHook getWebHook() {
+        return webHook;
+    }
+
+    public WebHookOptions getOptions() {
+        return options;
+    }
+
+    public int getOrder() {
+        return order;
+    }
+}
+

--- a/blade-core/src/test/java/com/hellokaton/blade/mvc/hook/WebHookOptionsTest.java
+++ b/blade-core/src/test/java/com/hellokaton/blade/mvc/hook/WebHookOptionsTest.java
@@ -1,0 +1,47 @@
+package com.hellokaton.blade.mvc.hook;
+
+import com.hellokaton.blade.mvc.route.Route;
+import com.hellokaton.blade.mvc.route.RouteMatcher;
+import com.hellokaton.blade.mvc.route.WebHookRoute;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class WebHookOptionsTest {
+
+    @Test
+    public void testSelectiveMiddlewareMatching() {
+        RouteMatcher matcher = new RouteMatcher();
+        WebHook hook1 = ctx -> true;
+        WebHookOptions opt1 = new WebHookOptions().addInclude("/api/*").addMethods("GET").priority(5);
+        matcher.addMiddleware(hook1, opt1);
+
+        WebHook hook2 = ctx -> true;
+        WebHookOptions opt2 = new WebHookOptions().addInclude("/api/admin").addExclude("/api/admin/private").priority(1);
+        matcher.addMiddleware(hook2, opt2);
+
+        List<Route> matched = matcher.getBefore("GET", "/api/admin");
+        assertEquals(2, matched.size());
+        assertEquals(hook2, ((WebHookRoute) matched.get(0)).getWebHook());
+
+        List<Route> matchedPost = matcher.getBefore("POST", "/api/admin");
+        assertTrue(matchedPost.isEmpty());
+
+        List<Route> matchedExclude = matcher.getBefore("GET", "/api/admin/private");
+        assertEquals(1, matchedExclude.size());
+        assertEquals(hook1, ((WebHookRoute) matchedExclude.get(0)).getWebHook());
+    }
+
+    @Test
+    public void testDuplicateIgnored() {
+        RouteMatcher matcher = new RouteMatcher();
+        WebHook hook = ctx -> true;
+        WebHookOptions opt = new WebHookOptions().addInclude("/api/*");
+        matcher.addMiddleware(hook, opt);
+        matcher.addMiddleware(hook, opt);
+        assertEquals(1, matcher.middlewareCount());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add WebHookOptions for include/exclude paths, method filters, priorities and conditions
- support WebHookRoute and sorted selective middleware retrieval
- expose Blade.use(WebHook, WebHookOptions) overload and adjust middleware execution

## Testing
- `mvn -q -pl blade-core test` *(failed: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68b1acb678748326bab5bc43d35e1a01