### PR TITLE
feat: add selective middleware options

### DIFF
--- a/blade-core/src/main/java/com/hellokaton/blade/Blade.java
+++ b/blade-core/src/main/java/com/hellokaton/blade/Blade.java
@@ -28,6 +28,7 @@ import com.hellokaton.blade.mvc.handler.DefaultExceptionHandler;
 import com.hellokaton.blade.mvc.handler.ExceptionHandler;
 import com.hellokaton.blade.mvc.handler.RouteHandler;
 import com.hellokaton.blade.mvc.hook.WebHook;
+import com.hellokaton.blade.mvc.hook.WebHookOptions;
 import com.hellokaton.blade.mvc.http.HttpMethod;
 import com.hellokaton.blade.mvc.http.session.SessionManager;
 import com.hellokaton.blade.mvc.route.RouteMatcher;
@@ -540,6 +541,12 @@ public class Blade {
             this.routeMatcher.addMiddleware(webHook);
             this.register(webHook);
         }
+        return this;
+    }
+
+    public Blade use(@NonNull WebHook middleware, @NonNull WebHookOptions options) {
+        this.routeMatcher.addMiddleware(middleware, options);
+        this.register(middleware);
         return this;
     }
 

--- a/blade-core/src/main/java/com/hellokaton/blade/mvc/hook/WebHookOptions.java
+++ b/blade-core/src/main/java/com/hellokaton/blade/mvc/hook/WebHookOptions.java
@@ -1,0 +1,175 @@
+package com.hellokaton.blade.mvc.hook;
+
+import com.hellokaton.blade.mvc.RouteContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+/**
+ * Options for {@link WebHook} registration allowing selective invocation.
+ */
+public class WebHookOptions {
+
+    private static final Logger log = LoggerFactory.getLogger(WebHookOptions.class);
+
+    private final List<String> includeSources = new ArrayList<>();
+    private final List<Pattern> includePatterns = new ArrayList<>();
+
+    private final List<String> excludeSources = new ArrayList<>();
+    private final List<Pattern> excludePatterns = new ArrayList<>();
+
+    private final Set<String> methods = new LinkedHashSet<>();
+
+    private int priority;
+    private Predicate<RouteContext> condition = ctx -> true;
+
+    public WebHookOptions() {
+    }
+
+    public WebHookOptions addInclude(String pattern) {
+        String norm = normalize(pattern);
+        if (includeSources.contains(norm)) {
+            return this;
+        }
+        includeSources.add(norm);
+        includePatterns.add(compileGlob(norm));
+        return this;
+    }
+
+    public WebHookOptions addExclude(String pattern) {
+        String norm = normalize(pattern);
+        if (excludeSources.contains(norm)) {
+            return this;
+        }
+        excludeSources.add(norm);
+        excludePatterns.add(compileGlob(norm));
+        return this;
+    }
+
+    public WebHookOptions addMethods(String... methods) {
+        if (null == methods) {
+            return this;
+        }
+        for (String method : methods) {
+            if (null == method) {
+                continue;
+            }
+            this.methods.add(method.toUpperCase(Locale.ROOT));
+        }
+        return this;
+    }
+
+    public WebHookOptions priority(int priority) {
+        this.priority = priority;
+        return this;
+    }
+
+    public WebHookOptions condition(Predicate<RouteContext> predicate) {
+        if (null != predicate) {
+            this.condition = predicate;
+        }
+        return this;
+    }
+
+    public List<Pattern> getIncludePatterns() {
+        return includePatterns;
+    }
+
+    public List<Pattern> getExcludePatterns() {
+        return excludePatterns;
+    }
+
+    public Set<String> getMethods() {
+        return methods;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public Predicate<RouteContext> getCondition() {
+        return condition;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        WebHookOptions that = (WebHookOptions) o;
+        return priority == that.priority &&
+                Objects.equals(includeSources, that.includeSources) &&
+                Objects.equals(excludeSources, that.excludeSources) &&
+                Objects.equals(methods, that.methods) &&
+                Objects.equals(condition, that.condition);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(includeSources, excludeSources, methods, priority, condition);
+    }
+
+    /**
+     * Normalize a request or pattern path.
+     */
+    public static String normalize(String path) {
+        if (path == null) {
+            return "/";
+        }
+        try {
+            path = URLDecoder.decode(path, StandardCharsets.UTF_8.name());
+        } catch (Exception ignore) {
+        }
+        int q = path.indexOf('?');
+        if (q >= 0) {
+            path = path.substring(0, q);
+        }
+        int f = path.indexOf('#');
+        if (f >= 0) {
+            path = path.substring(0, f);
+        }
+        path = path.replaceAll("/+", "/");
+        if (!path.startsWith("/")) {
+            path = "/" + path;
+        }
+        if (path.length() > 1 && path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+        return path.toLowerCase(Locale.ROOT);
+    }
+
+    private static Pattern compileGlob(String pattern) {
+        StringBuilder regex = new StringBuilder();
+        boolean escaping = false;
+        for (int i = 0; i < pattern.length(); i++) {
+            char c = pattern.charAt(i);
+            if (escaping) {
+                regex.append(Pattern.quote(String.valueOf(c)));
+                escaping = false;
+                continue;
+            }
+            if (c == '\\') {
+                if (i == pattern.length() - 1) {
+                    log.warn("SelectiveMiddleware: dangling escape in pattern {}", pattern);
+                    regex.append("\\\\");
+                } else {
+                    escaping = true;
+                }
+                continue;
+            }
+            if (c == '*') {
+                regex.append(".*");
+            } else if (c == '?') {
+                regex.append("[^/]");
+            } else {
+                regex.append(Pattern.quote(String.valueOf(c)));
+            }
+        }
+        return Pattern.compile(regex.toString(), Pattern.CASE_INSENSITIVE);
+    }
+}
+

--- a/blade-core/src/test/java/com/hellokaton/blade/mvc/SelectiveMiddlewareTest.java
+++ b/blade-core/src/test/java/com/hellokaton/blade/mvc/SelectiveMiddlewareTest.java
@@ -1,0 +1,51 @@
+package com.hellokaton.blade.mvc;
+
+import com.hellokaton.blade.BaseTestCase;
+import com.hellokaton.blade.mvc.hook.WebHook;
+import com.hellokaton.blade.mvc.hook.WebHookOptions;
+import com.hellokaton.blade.mvc.route.RouteMatcher;
+import com.hellokaton.blade.mvc.http.Response;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+public class SelectiveMiddlewareTest extends BaseTestCase {
+
+    @Test
+    public void testSelectiveMiddlewareMatching() {
+        RouteMatcher matcher = new RouteMatcher();
+
+        WebHook hook1 = ctx -> true;
+        WebHookOptions opt1 = new WebHookOptions().addInclude("/api/*").addMethods("GET").priority(1);
+
+        WebHook hook2 = ctx -> true;
+        WebHookOptions opt2 = new WebHookOptions().addInclude("/api/test").priority(0);
+
+        matcher.addMiddleware(hook1, opt1);
+        matcher.addMiddleware(hook2, opt2);
+
+        com.hellokaton.blade.mvc.http.HttpRequest request = mockHttpRequest("GET");
+        when(request.url()).thenReturn("/api/test");
+        when(request.uri()).thenReturn("/api/test");
+        when(request.httpMethod()).thenReturn(com.hellokaton.blade.mvc.http.HttpMethod.GET);
+        Response response = mockHttpResponse(200);
+        RouteContext ctx = new RouteContext(request, response);
+
+        java.util.List<RouteMatcher.Middleware> list = matcher.getMiddleware(ctx);
+        assertEquals(2, list.size());
+        assertSame(hook2, list.get(0).getHook());
+        assertSame(hook1, list.get(1).getHook());
+
+        com.hellokaton.blade.mvc.http.HttpRequest request2 = mockHttpRequest("GET");
+        when(request2.url()).thenReturn("/api/test/ignore");
+        when(request2.uri()).thenReturn("/api/test/ignore");
+        when(request2.httpMethod()).thenReturn(com.hellokaton.blade.mvc.http.HttpMethod.GET);
+        RouteContext ctx2 = new RouteContext(request2, response);
+
+        java.util.List<RouteMatcher.Middleware> list2 = matcher.getMiddleware(ctx2);
+        assertEquals(1, list2.size());
+        assertSame(hook1, list2.get(0).getHook());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add WebHookOptions to control middleware activation via path, method, priority, and predicates
- support middleware registration with options and per-request filtering
- test selective middleware matching behavior

## Testing
- `mvn -q -pl blade-core -am test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1; Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68b1b55c75388326b815be6f8a2bef5b