### PR TITLE
Add selective middleware options for Blade

### DIFF
--- a/blade-core/src/main/java/com/hellokaton/blade/Blade.java
+++ b/blade-core/src/main/java/com/hellokaton/blade/Blade.java
@@ -28,6 +28,7 @@ import com.hellokaton.blade.mvc.handler.DefaultExceptionHandler;
 import com.hellokaton.blade.mvc.handler.ExceptionHandler;
 import com.hellokaton.blade.mvc.handler.RouteHandler;
 import com.hellokaton.blade.mvc.hook.WebHook;
+import com.hellokaton.blade.mvc.hook.WebHookOptions;
 import com.hellokaton.blade.mvc.http.HttpMethod;
 import com.hellokaton.blade.mvc.http.session.SessionManager;
 import com.hellokaton.blade.mvc.route.RouteMatcher;
@@ -239,6 +240,11 @@ public class Blade {
      */
     public Blade before(@NonNull String path, @NonNull RouteHandler handler) {
         this.routeMatcher.addRoute(path, handler, HttpMethod.BEFORE);
+        return this;
+    }
+
+    public Blade before(@NonNull String path, @NonNull RouteHandler handler, WebHookOptions options) {
+        this.routeMatcher.addRoute(path, handler, HttpMethod.BEFORE, options);
         return this;
     }
 
@@ -540,6 +546,12 @@ public class Blade {
             this.routeMatcher.addMiddleware(webHook);
             this.register(webHook);
         }
+        return this;
+    }
+
+    public Blade use(@NonNull WebHook webHook, WebHookOptions options) {
+        this.routeMatcher.addMiddleware(webHook, options);
+        this.register(webHook);
         return this;
     }
 

--- a/blade-core/src/main/java/com/hellokaton/blade/mvc/hook/WebHookOptions.java
+++ b/blade-core/src/main/java/com/hellokaton/blade/mvc/hook/WebHookOptions.java
@@ -1,0 +1,227 @@
+package com.hellokaton.blade.mvc.hook;
+
+import com.hellokaton.blade.kit.PathKit;
+import com.hellokaton.blade.mvc.RouteContext;
+import com.hellokaton.blade.mvc.http.HttpMethod;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+/**
+ * Options used for selective middleware and hook invocation.
+ *
+ * <p>This class is fluent and every mutator returns {@code this}.</p>
+ */
+@Slf4j
+public class WebHookOptions {
+
+    private static final Pattern SLASHES = Pattern.compile("/+\");
+
+    private final Set<String> includes = new LinkedHashSet<>();
+    private final Set<String> excludes = new LinkedHashSet<>();
+    private final List<Pattern> includePatterns = new ArrayList<>();
+    private final List<Pattern> excludePatterns = new ArrayList<>();
+
+    private EnumSet<HttpMethod> methods = null;
+
+    @Getter
+    private int priority = 0;
+
+    @Getter
+    private Predicate<RouteContext> predicate = null;
+
+    @Getter
+    private long order = 0L;
+
+    public WebHookOptions() {
+    }
+
+    /**
+     * Include one or more path patterns. Blank entries are ignored.
+     */
+    public WebHookOptions addIncludes(String... patterns) {
+        addPatterns(patterns, true);
+        return this;
+    }
+
+    /**
+     * Exclude one or more path patterns. Blank entries are ignored.
+     */
+    public WebHookOptions addExcludes(String... patterns) {
+        addPatterns(patterns, false);
+        return this;
+    }
+
+    private void addPatterns(String[] patterns, boolean include) {
+        if (null == patterns) return;
+        for (String raw : patterns) {
+            if (null == raw) continue;
+            String p = raw.trim();
+            if (p.isEmpty()) continue;
+            String norm = normalizePattern(p);
+            Pattern compiled = compile(norm);
+            if (include) {
+                if (includes.add(norm)) {
+                    includePatterns.add(compiled);
+                }
+            } else {
+                if (excludes.add(norm)) {
+                    excludePatterns.add(compiled);
+                }
+            }
+        }
+    }
+
+    private String normalizePattern(String p) {
+        String path = PathKit.fixPath(p);
+        try {
+            path = URLDecoder.decode(path, StandardCharsets.UTF_8.name());
+        } catch (Exception ignored) {
+        }
+        path = SLASHES.matcher(path).replaceAll("/");
+        if (path.length() > 1 && path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+        return path.toLowerCase(Locale.ROOT);
+    }
+
+    private Pattern compile(String pattern) {
+        StringBuilder sb = new StringBuilder();
+        boolean escaping = false;
+        for (int i = 0; i < pattern.length(); i++) {
+            char c = pattern.charAt(i);
+            if (escaping) {
+                sb.append(Pattern.quote(String.valueOf(c)));
+                escaping = false;
+            } else {
+                switch (c) {
+                    case '*':
+                        sb.append(".*");
+                        break;
+                    case '?':
+                        sb.append("[^/]");
+                        break;
+                    case '\\':
+                        escaping = true;
+                        break;
+                    default:
+                        sb.append(Pattern.quote(String.valueOf(c)));
+                }
+            }
+        }
+        if (escaping) {
+            log.warn("SelectiveMiddleware: Dangling escape in pattern {}", pattern);
+            sb.append(Pattern.quote("\\"));
+        }
+        try {
+            return Pattern.compile(sb.toString(), Pattern.CASE_INSENSITIVE);
+        } catch (Exception e) {
+            log.warn("SelectiveMiddleware: {}", e.getMessage());
+            return Pattern.compile(Pattern.quote(pattern), Pattern.CASE_INSENSITIVE);
+        }
+    }
+
+    /**
+     * Constrain matching to specific HTTP methods.
+     */
+    public WebHookOptions addMethods(HttpMethod... mths) {
+        if (null == mths) return this;
+        if (null == methods) {
+            methods = EnumSet.noneOf(HttpMethod.class);
+        }
+        for (HttpMethod m : mths) {
+            if (null != m) {
+                methods.add(m);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Constrain matching to specific HTTP methods from String values.
+     * Unrecognised strings are ignored silently.
+     */
+    public WebHookOptions addMethods(String... mths) {
+        if (null == mths) return this;
+        for (String m : mths) {
+            if (null == m) continue;
+            String t = m.trim();
+            if (t.isEmpty()) continue;
+            try {
+                addMethods(HttpMethod.valueOf(t.toUpperCase(Locale.ROOT)));
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Assign execution priority. Lower numbers run earlier.
+     */
+    public WebHookOptions priority(int p) {
+        this.priority = p;
+        return this;
+    }
+
+    /**
+     * Supply a runtime predicate used to gate execution.
+     */
+    public WebHookOptions predicate(Predicate<RouteContext> predicate) {
+        this.predicate = predicate;
+        return this;
+    }
+
+    public void setOrder(long order) {
+        this.order = order;
+    }
+
+    public Set<HttpMethod> methods() {
+        return methods == null ? Collections.emptySet() : methods;
+    }
+
+    public boolean matchPath(String path) {
+        boolean matched = includes.isEmpty();
+        if (!includes.isEmpty()) {
+            for (Pattern p : includePatterns) {
+                if (p.matcher(path).matches()) {
+                    matched = true;
+                    break;
+                }
+            }
+        }
+        if (!matched) return false;
+        for (Pattern p : excludePatterns) {
+            if (p.matcher(path).matches()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public boolean matchMethod(HttpMethod method) {
+        return methods == null || methods.isEmpty() || methods.contains(method);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        WebHookOptions that = (WebHookOptions) o;
+        return priority == that.priority &&
+                Objects.equals(includes, that.includes) &&
+                Objects.equals(excludes, that.excludes) &&
+                Objects.equals(methods(), that.methods()) &&
+                Objects.equals(predicate, that.predicate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(includes, excludes, methods(), priority, predicate);
+    }
+}
+

--- a/blade-core/src/main/java/com/hellokaton/blade/mvc/route/Route.java
+++ b/blade-core/src/main/java/com/hellokaton/blade/mvc/route/Route.java
@@ -59,6 +59,10 @@ public class Route {
 
     private int sort;
 
+    private com.hellokaton.blade.mvc.hook.WebHookOptions webHookOptions;
+
+    private long registerOrder;
+
     /**
      * Url path params
      */
@@ -107,6 +111,8 @@ public class Route {
         this.isWildcard = route.isWildcard;
         this.responseType = route.responseType;
         this.sort = route.sort;
+        this.webHookOptions = route.webHookOptions;
+        this.registerOrder = route.registerOrder;
     }
 
     public String getAllPath() {

--- a/blade-kit/src/main/java/com/hellokaton/blade/kit/PathKit.java
+++ b/blade-kit/src/main/java/com/hellokaton/blade/kit/PathKit.java
@@ -44,6 +44,40 @@ public class PathKit {
         return path.replaceAll("[/]+", SLASH);
     }
 
+    /**
+     * Normalize a request path for matching.
+     * <p>
+     * This extracts the path component, decodes percent-encoding,
+     * collapses duplicate slashes and removes a trailing slash
+     * (except for the root path). Result is lower-cased using
+     * {@link java.util.Locale#ROOT}.
+     * </p>
+     *
+     * @param uri original request URI or path
+     * @return normalized lower-case path
+     */
+    public static String normalize(String uri) {
+        if (null == uri || uri.isEmpty()) {
+            return SLASH;
+        }
+        String path;
+        try {
+            java.net.URI u = new java.net.URI(fixPath(uri));
+            path = u.getPath();
+        } catch (Exception e) {
+            path = fixPath(uri);
+        }
+        try {
+            path = java.net.URLDecoder.decode(path, java.nio.charset.StandardCharsets.UTF_8.name());
+        } catch (Exception ignored) {
+        }
+        path = cleanPath(path);
+        if (path.length() > 1 && path.endsWith(SLASH)) {
+            path = path.substring(0, path.length() - 1);
+        }
+        return path.toLowerCase(java.util.Locale.ROOT);
+    }
+
     private class Node {
         private String path;
         private String segment;


### PR DESCRIPTION
## Summary
- add `WebHookOptions` for include/exclude patterns, method filters, priority and predicates
- enable selective `Blade.use` and `Blade.before` via new overloads using glob-matching and ordered execution
- normalize request paths and skip middleware/hook execution when constraints fail or throw

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68b27d573fb48326a917e1e2de7ca6c8